### PR TITLE
Improve scripts

### DIFF
--- a/scripts/rpi.monitor_3dr.sh
+++ b/scripts/rpi.monitor_3dr.sh
@@ -1,48 +1,47 @@
 #!/bin/bash
 
-MAVLINKENABLED=`cat /opt/sdr/sparrow/sparrow-wifi/sparrowwifiagent.cfg | grep "^mavlink" | wc -l`
+MAVLINKENABLED=$(cat /opt/sparrow-wifi/sparrowwifiagent.cfg | grep "^mavlink" | wc -l)
 
-if [ $MAVLINKENABLED -eq 0 ]; then
+if [ "$MAVLINKENABLED" -eq 0 ]; then
 	# echo "Mavlink not enabled. Exiting."
 	exit 0
 fi
 
 IFACE="wlan0"
 
-IPADDR=`ifconfig $IFACE | grep -Eo 'inet addr\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -Eo "[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}"`
+IPADDR=$(ifconfig $IFACE | grep -Eo 'inet addr\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -Eo "[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}")
 
-ISTENNET=`echo "$IPADDR" | grep "^10\.1\.1" | wc -l`
+ISTENNET=$(echo "$IPADDR" | grep "^10\.1\.1" | wc -l)
 
-AGENTRUNNING=`ps aux | grep "sparrowwifiagent.py" | grep -v grep | wc -l`
-if [ $ISTENNET -eq 1 ]; then
+AGENTRUNNING=$(ps aux | grep "sparrowwifiagent.py" | grep -v grep | wc -l)
+if [ "$ISTENNET" -eq 1 ]; then
 	# We're connected
-	if [ $AGENTRUNNING -eq 0 ]; then
+	if [ "$AGENTRUNNING" -eq 0 ]; then
 		# Check if it should be running
-		if [ -e /opt/sdr/sparrow/sparrow-wifi/sparrowwifiagent.cfg ]; then
-			CANCELSTART=`cat /opt/sdr/sparrow/sparrow-wifi/sparrowwifiagent.cfg | grep -Ei "^cancelstart.*?true" | wc -l`
+		if [ -e /opt/sparrow-wifi/sparrowwifiagent.cfg ]; then
+			CANCELSTART=$(cat /opt/sparrow-wifi/sparrowwifiagent.cfg | grep -Ei "^cancelstart.*?true" | wc -l)
 		else
 			CANCELSTART=0
 		fi
 
-		if [ $CANCELSTART -eq 0 ]; then
-			echo "[`date`] Starting agent"
-			echo "[`date`] Starting Sparrow Wifi agent" >> /var/log/rpisparrowagent.log
-			cd /opt/sdr/sparrow/sparrow-wifi/
+		if [ "$CANCELSTART" -eq 0 ]; then
+			echo "[$(date)] Starting agent"
+			echo "[$(date)] Starting Sparrow Wifi agent" >> /var/log/rpisparrowagent.log
+			cd /opt/sparrow-wifi/
 
-			/usr/local/bin/python3.5 ./sparrowwifiagent.py &
+			python ./sparrowwifiagent.py &
 		fi
 	fi
 else
 	# Not in ten net
-	if [ $AGENTRUNNING -gt 0 ]; then
-		echo "[`date`] Stopping agent"
-		echo "[`date`] Stopping Sparrow Wifi agent" >> /var/log/rpisparrowagent.log
+	if [ "$AGENTRUNNING" -gt 0 ]; then
+		echo "[$(date)] Stopping agent"
+		echo "[$(date)] Stopping Sparrow Wifi agent" >> /var/log/rpisparrowagent.log
 		# Send keyboard interrupt
-		pkill -2 -f "python3.5.*sparrowwifiagent.py.*"
+		pkill -2 -f "python.*sparrowwifiagent.py.*"
 		# wait for HTTP server to stop
 		sleep 1
 		# force kill agent if it didn't stop on its own
-		pkill -9 -f "python3.5.*sparrowwifiagent.py.*"
+		pkill -9 -f "python.*sparrowwifiagent.py.*"
 	fi
 fi
-

--- a/scripts/rpi.sparrowagentstart.sh
+++ b/scripts/rpi.sparrowagentstart.sh
@@ -1,24 +1,25 @@
 #!/bin/bash
 
-cd /opt/sdr/sparrow/sparrow-wifi/
+cd /opt/sparrow-wifi/
 
-GPSDRUNNING=`service gpsd status | grep "Active.*dead" | wc -l`
+GPSDRUNNING=$(service gpsd status | grep "Active.*dead" | wc -l)
 
 # If the service isn't dead stop it
-if [ $GPSRUNNING -eq 0 ]; then
+if [ "$GPSDRUNNING" -eq 0 ]; then
 	service gpsd stop
 fi
 
-GPSDRUNNING=`pgrep gpsd | wc -l`
+GPSRUNNING=$(pgrep gpsd | wc -l
 
 # See if it was already started with the command below
-if [ $GPSRUNNING -eq 0 ]; then
+if [ "$GPSRUNNING" -eq 0 ]; then
 	# We only care if the ttyUSB0 port is present indicating the GPS is actually plugged in
 	if [ -e /dev/ttyUSB0 ]; then
 		gpsd -G /dev/ttyUSB0
 	fi
 fi
 
-/usr/local/bin/python3.5 ./sparrowwifiagent.py &
+python sparrowwifiagent.py &
+
 
 

--- a/scripts/rpi.sparrowagentstart.sh
+++ b/scripts/rpi.sparrowagentstart.sh
@@ -20,6 +20,3 @@ if [ "$GPSRUNNING" -eq 0 ]; then
 fi
 
 python sparrowwifiagent.py &
-
-
-

--- a/scripts/rpi.sparrowagentstart.sh
+++ b/scripts/rpi.sparrowagentstart.sh
@@ -9,7 +9,7 @@ if [ "$GPSDRUNNING" -eq 0 ]; then
 	service gpsd stop
 fi
 
-GPSRUNNING=$(pgrep gpsd | wc -l
+GPSRUNNING=$(pgrep gpsd | wc -l)
 
 # See if it was already started with the command below
 if [ "$GPSRUNNING" -eq 0 ]; then

--- a/scripts/rpi.sparrowagentstop.sh
+++ b/scripts/rpi.sparrowagentstop.sh
@@ -3,4 +3,3 @@
 pkill -2 -f "python.*sparrowwifiagent.py.*"
 sleep 1
 pkill -9 -f "python.*sparrowwifiagent.py.*"
-

--- a/scripts/rpi.sparrowagentstop.sh
+++ b/scripts/rpi.sparrowagentstop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pkill -2 -f "python3.5.*sparrowwifiagent.py.*"
+pkill -2 -f "python.*sparrowwifiagent.py.*"
 sleep 1
-pkill -9 -f "python3.5.*sparrowwifiagent.py.*"
+pkill -9 -f "python.*sparrowwifiagent.py.*"
 


### PR DESCRIPTION
- What is the purpose of `/opt/sdr/sparrow/sparrow-wifi/`? Simplified to `/opt/sparrow-wifi/` as there are not multiple components requiring nested folders.

- Do not hardcode the Python path and version. No matter how someone has Python installed, it should be in their `$PATH`.

- [SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006): Use `$(...)` notation instead of legacy backticked `` `...` ``
- [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086): Double quote to prevent globbing and word splitting

- Fix `GPSDRUNNING` / `GPSRUNNING` typo

- Running a Python script does not require `./`