### PR TITLE
sparrow-wifi.py: handle case where "interfaces" returns as NoneType

### DIFF
--- a/sparrow-wifi.py
+++ b/sparrow-wifi.py
@@ -3486,7 +3486,9 @@ class mainWindow(QMainWindow):
                     
                 # Okay, we have interfaces.  Let's load them
                 self.combo.clear()
-                if (len(interfaces) > 0):
+
+                # Double check your objects
+                if interfaces is not None and len(interfaces) > 0:
                     for curInterface in interfaces:
                         self.combo.addItem(curInterface)
                 else:


### PR DESCRIPTION
This pull request handles the case where `interfaces` returns as `NoneType` due to no wireless interfaces being found on the host device. Without it, the program will raise an error and crash.

This also fixes #35 