### PR TITLE
Use more general shebang to launch python

### DIFF
--- a/sparrow-wifi.py
+++ b/sparrow-wifi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # 
 # Copyright 2017 ghostop14
 # 


### PR DESCRIPTION
By using env instead python directly, we can invoke the executable with
any python we want. This feature is very useful when running the
application in a customized python virtual environment.

The application `sparrow-wifi.py` was tested with packages[1] in a python virtual environment created by pipenv and scanning bands in my house successfully.

[1]
```
$ python --version
Python 3.8.3
$ pip list
Package         Version
--------------- ---------
certifi         2020.12.5
chardet         4.0.0
cycler          0.10.0
gps3            0.33.3
idna            2.10
kiwisolver      1.3.1
matplotlib      3.3.3
numpy           1.19.4
Pillow          8.1.0
pip             20.3.3
pyparsing       2.4.7
PyQt5           5.15.2
PyQt5-sip       12.8.1
PyQtChart       5.13.1
python-dateutil 2.8.1
requests        2.25.1
setuptools      51.1.1
six             1.15.0
urllib3         1.26.2
wheel           0.36.2
```