### PR TITLE
Fix decoding of CLI output that contains non-ASCII characters

### DIFF
--- a/wirelessengine.py
+++ b/wirelessengine.py
@@ -494,7 +494,12 @@ class WirelessEngine(object):
         
     def getInterfaces(printResults=False):
         result = subprocess.run(['iwconfig'], stdout=subprocess.PIPE,stderr=subprocess.DEVNULL)
-        wirelessResult = result.stdout.decode('ASCII')
+
+        try:
+            wirelessResult = result.stdout.decode('ASCII')
+        except UnicodeDecodeError:
+            wirelessResult = result.stdout.decode('UTF-8')
+
         p = re.compile('^(.*?) IEEE', re.MULTILINE)
         tmpInterfaces = p.findall(wirelessResult)
         
@@ -518,7 +523,12 @@ class WirelessEngine(object):
         # Note: for standard scans with iw, this isn't required.  Just root access.
         # This is only required for some of the more advanced pen testing capabilities
         result = subprocess.run(['iwconfig'], stdout=subprocess.PIPE,stderr=subprocess.DEVNULL)
-        wirelessResult = result.stdout.decode('ASCII')
+
+        try:
+            wirelessResult = result.stdout.decode('ASCII')
+        except UnicodeDecodeError:
+            wirelessResult = result.stdout.decode('UTF-8')
+
         p = re.compile('^(.*?) IEEE.*?Mode:Monitor', re.MULTILINE)
         tmpInterfaces = p.findall(wirelessResult)
         
@@ -626,8 +636,12 @@ class WirelessEngine(object):
 
         retCode = result.returncode
         errString = ""
-        wirelessResult = result.stdout.decode('ASCII')
-        
+
+        try:
+            wirelessResult = result.stdout.decode('ASCII')
+        except UnicodeDecodeError:
+            wirelessResult = result.stdout.decode('UTF-8')
+
         # debug
         if (printResults):
             print('Return Code ' + str(retCode))


### PR DESCRIPTION
## Problem / Issue:

Output from (external) command line tools that are parsed and decoded by sparrow-wifi sometimes contain non-ASCII / unicode characters. At this time, sparrow-wifi crashes when non-ASCII characters are encountered... it throws an error such as shown below. Once the error is thrown, the sparrow GUI freezes and has to be force killed:

```
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/opt/sparrow-wifi/sparrow-wifi.py", line 499, in run
    retCode, errString, wirelessNetworks = WirelessEngine.scanForNetworks(self.interface)
  File "/opt/sparrow-wifi/wirelessengine.py", line 629, in scanForNetworks
    wirelessResult = result.stdout.decode('ASCII')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 190404: ordinal not in range(128)
```

## Proposed Solution:

Decode the externally-received output as ASCII and, if that fails, fallback to UTF-8 decoding. Alternatively, it might be safe enough to just do UTF-8 decoding at all times, and remove the ASCII decoding attempt altogether?

## Environment Info:

- OS:  Debian Linux Buster 10.6 w/ KDE 5
- iw:  iw version 5.0.1
- Python:  Python 3.7.3 (default, Jul 25 2020, 13:03:44)
- sparrow-wifi:  Master branch, commit c811606 (https://github.com/ghostop14/sparrow-wifi/commit/c81160674fa52c7d2ad3454854304c4510d97ce4)

## Further Info:

I encountered this issue due to a random WiFi client device in my neighborhood that contains non-ASCII information in the "WPS" section of its output from the external command `iw dev <dev> scan`. 

Below is an output showing the non-ASCII character present in the WPS Device name field... the character that looks like an apostrophe in the string "**Ray's Roku**", is in fact a non-ASCII character.

```
BSS da:31:34:XX:XX:XX(on wlp3s0)
        last seen: 2301295.830s [boottime]
        TSF: 3743687373252 usec (43d, 07:54:47)
        freq: 2437
        beacon interval: 100 TUs
        capability: ESS Privacy ShortSlotTime (0x0411)
        signal: -79.00 dBm
        last seen: 636 ms ago
        SSID: 
        Supported rates: 6.0* 9.0 12.0* 18.0 24.0* 36.0 48.0 54.0 
        DS Parameter set: channel 6
        TIM: DTIM Count 0 DTIM Period 1 Bitmap Control 0x0 Bitmap[0] 0x0
        Country: US     Environment: Indoor/Outdoor
                Channels [1 - 11] @ -128 dBm
        ERP: Barker_Preamble_Mode
        RSN:     * Version: 1
                 * Group cipher: CCMP
                 * Pairwise ciphers: CCMP
                 * Authentication suites: PSK
                 * Capabilities: 16-PTKSA-RC 1-GTKSA-RC (0x000c)
        HT capabilities:
                Capabilities: 0x92c
                        HT20
                        SM Power Save disabled
                        RX HT20 SGI
                        RX STBC 1-stream
                        Max AMSDU length: 7935 bytes
                        No DSSS/CCK HT40
                Maximum RX AMPDU length 65535 bytes (exponent: 0x003)
                Minimum RX AMPDU time spacing: 16 usec (0x07)
                HT Max RX data rate: 150 Mbps
                HT TX/RX MCS rate indexes supported: 0-7
        HT operation:
                 * primary channel: 6
                 * secondary channel offset: no secondary
                 * STA channel width: 20 MHz
                 * RIFS: 0
                 * HT protection: no
                 * non-GF present: 0
                 * OBSS non-GF present: 0
                 * dual beacon: 0
                 * dual CTS protection: 0
                 * STBC beacon: 0
                 * L-SIG TXOP Prot: 0
                 * PCO active: 0
                 * PCO phase: 0
        WMM:     * Parameter version 1
                 * u-APSD
                 * BE: CW 15-1023, AIFSN 3
                 * BK: CW 15-1023, AIFSN 7
                 * VI: CW 7-15, AIFSN 2, TXOP 2976 usec
                 * VO: CW 1-1, AIFSN 1, TXOP 1472 usec
        WPS:     * Version: 1.0
                 * Wi-Fi Protected Setup State: 2 (Configured)
                 * Unknown TLV (0x1049, 6 bytes): 00 37 2a 00 01 20
                 * Device name: Ray’s Roku
                 * Primary Device Type: 7-0050f204-1
        P2P:     * Group capa: 0x21, Device capa: 0x0b
                 * Unknown TLV (0x03, 6 bytes): 31 34 44 67 c5 dd
```