### PR TITLE
Fix Python 3.12 \ invalid escape warning

### DIFF
--- a/wirelessengine.py
+++ b/wirelessengine.py
@@ -671,7 +671,7 @@ class WirelessEngine(object):
     def parseIWoutput(iwOutput):
         
         # Define search regexes once:
-        p_bss = re.compile('^BSS (.*?)\(')
+        p_bss = re.compile(r'^BSS (.*?)\(')
         p_ssid = re.compile('^.+?SSID: +(.*)')
         p_ess = re.compile('^	capability:.*(ESS)')
         p_ess_privacy = re.compile('^	capability:.*(ESS Privacy)')
@@ -682,7 +682,7 @@ class WirelessEngine(object):
         p_param_channel = re.compile('^.*?DS Parameter set: channel +([0-9]+).*')
         p_primary_channel = re.compile('^.*?primary channel: +([0-9]+).*')
         p_freq = re.compile('^.*?freq:.*?([0-9]+).*')
-        p_signal = re.compile('^.*?signal:.*?([\-0-9]+).*?dBm')
+        p_signal = re.compile(r'^.*?signal:.*?([\-0-9]+).*?dBm')
         p_ht = re.compile('.*?HT20/HT40.*')
         p_bw = re.compile('.*?\\* channel width:.*?([0-9]+) MHz.*')
         p_secondary = re.compile('^.*?secondary channel offset: *([^ \\t]+).*')


### PR DESCRIPTION
Fix the following warnings:
```
/usr/share/sparrow-wifi/wirelessengine.py:674: SyntaxWarning: invalid escape sequence '\('
  p_bss = re.compile('^BSS (.*?)\(')
/usr/share/sparrow-wifi/wirelessengine.py:685: SyntaxWarning: invalid escape sequence '\-'
  p_signal = re.compile('^.*?signal:.*?([\-0-9]+).*?dBm')
/usr/share/sparrow-wifi/sparrowbluetooth.py:369: SyntaxWarning: invalid escape sequence '\('
  p_company = re.compile('Company: (.*) \(')
/usr/share/sparrow-wifi/plugins/falconwifi.py:702: SyntaxWarning: invalid escape sequence '\!'
  p = re.compile('KEY FOUND\! \[(.*?)\].*')
/usr/share/sparrow-wifi/plugins/falconwifi.py:780: SyntaxWarning: invalid escape sequence '\!'
  p = re.compile('KEY FOUND\! \[(.*?)\].*')
```