### PR TITLE
Use nmcli or iw (if available) to list interfaces, instead of iwconfig

### DIFF
--- a/wirelessengine.py
+++ b/wirelessengine.py
@@ -499,7 +499,7 @@ class WirelessEngine(object):
     def getInterfaces(printResults=False) -> list:
         """ Returns a list of wireless interfaces using the `nmcli device status`,`iwconfig`, or `iw dev` command. """
         programs = {
-                ('nmcli', '--colors', 'no', 'device', 'status'): '^(w[a-z0-9]+)\\s+wifi\\s+',
+                ('nmcli', '--colors', 'no', '--terse'): '^(w[a-z0-9]+):wifi:',
                 ('iwconfig'):  "^(w.*?) .*",
                 ('iw', 'dev'): "Interface (w[a-z0-9]+)",
         }

--- a/wirelessengine.py
+++ b/wirelessengine.py
@@ -499,7 +499,7 @@ class WirelessEngine(object):
     def getInterfaces(printResults=False) -> list:
         """ Returns a list of wireless interfaces using the `nmcli device status`,`iwconfig`, or `iw dev` command. """
         programs = {
-                ('nmcli', '--colors', 'no', 'device', 'status'): '^w([a-z0-9]+)\\s+wifi\\s+',
+                ('nmcli', '--colors', 'no', 'device', 'status'): '^(w[a-z0-9]+)\\s+wifi\\s+',
                 ('iwconfig'):  "^(w.*?) .*",
                 ('iw', 'dev'): "Interface (w[a-z0-9]+)",
         }


### PR DESCRIPTION
Adds the ability to use `nmcli` or `iw` (if installed), instead of `iwconfig`.

Warnings:
- the help for `iw dev` advises 'Do NOT screenscrape this tool', but this patch does exactly that, if `nmcli` is not installed.
- there is another method which uses iwconfig to get the monitoring mode interfaces, and this patch doesn't fix that method.