### PR TITLE
DroneID: add API-Based Alerting channel alongside Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ A standalone web-based drone detection and tracking system that decodes FAA-mand
 - **Real-time map** &mdash; Leaflet-based map with quadcopter icons, heading indicators, operator position markers, and drone-to-operator lines
 - **At-a-glance labels** &mdash; Operator ID and altitude AGL displayed under each drone icon on the map
 - **Detail popups** &mdash; Click a drone for serial, registration ID, operator ID, type, speed, heading, altitude, bearing/range from receiver, BVLOS status
-- **Alert system** &mdash; Configurable alerts for new drones, altitude violations, speed violations, and signal loss with audio tones, visual toasts, and Slack webhook notifications
+- **Alert system** &mdash; Configurable alerts for new drones, altitude violations, speed violations, and signal loss with audio tones, visual toasts, Slack webhook notifications, and optional bearer-token JSON POSTs to a generic external alert-ingest API (see [API-Based Alerting](#api-based-alerting) below)
 - **Alert acknowledgment** &mdash; Three-state workflow (Active/Acknowledged/Resolved) with operator identity, shared across all connected devices
 - **Airport geozones** &mdash; Automatic download and display of nearby airports (OurAirports data) and FAA Prohibited/Restricted airspace polygons, cached locally for offline operation
 - **GPS** &mdash; gpsd integration or configurable static coordinates
@@ -73,6 +73,71 @@ A standalone web-based drone detection and tracking system that decodes FAA-mand
 - **Metric / Imperial** &mdash; Full unit preference support throughout the UI and alerts
 
 Web UI runs at `http://localhost:8097` once started. See [Installation](#sparrow-droneid-web-application-1) below for setup, and the [API reference](sparrow-droneid/sparrow_drone_id_api.md) for programmatic access.
+
+### API-Based Alerting
+
+In addition to Slack webhooks, Sparrow DroneID can POST each fired alert
+to a generic external alert-ingest endpoint. The channel is **disabled
+by default**; configure it in Settings → Alerts → API-Based Alerting:
+
+- **Enable** &mdash; on/off toggle
+- **API Endpoint Root** &mdash; full root URL including any path prefix, e.g. `http://MY_API_HOST:PORT/API_ROOT`
+- **Domain** &mdash; opaque tenant string the receiving API uses to route alerts
+- **Bearer Token** &mdash; sent in the `Authorization: Bearer ...` header; masked in the UI once stored
+- **Verify TLS** &mdash; uncheck for self-signed or private-CA endpoints
+- **Test Auth** &mdash; calls the receiver's verify endpoint and reports a clear pass/fail
+- **Send Test Message** &mdash; POSTs a synthetic alert (`rule.category: "test"`, serial `TEST-0000`) so the receiver can be exercised end-to-end without waiting for a real drone
+
+#### Endpoint contract
+
+Sparrow DroneID makes two calls against the configured root URL:
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| `POST` | `{root}/v1/alerts/verify` | Credential check &mdash; body `{"domain": "<configured>"}`. Receiver should reply `200 {"status":"ok"}` on success, `401` on bad token. |
+| `POST` | `{root}/v1/alerts` | Fire an alert &mdash; body is the JSON below. Receiver should reply `201 {"alert_id":"..."}` on success. `503` responses are retried with exponential backoff (3 retries); `4xx` aborts without retry. A `200 {"status":"dropped"}` indicates the domain is disabled upstream. |
+
+Both calls send `Authorization: Bearer <token>` and `Content-Type: application/json`.
+
+#### Payload shape
+
+```json
+{
+  "domain": "<configured>",
+  "alert": {
+    "message": "<human-readable text identical to the Slack body>",
+    "observer": {
+      "name": "<operator_name or 'Sparrow DroneID'>",
+      "type": "drone-sensor",
+      "geo": {"location": {"lat": 0.0, "lon": 0.0}}
+    },
+    "rule":  {"name": "<alert type label>", "category": "drone_detection"},
+    "event": {
+      "severity": 40,
+      "category": "network",
+      "action":   "new_drone"
+    },
+    "labels": {
+      "serial":     "<drone serial>",
+      "vendor":     "<resolved vendor>",
+      "ua_type":    "<UA type display name>",
+      "alert_type": "new_drone | altitude_max | speed_max | signal_lost"
+    },
+    "source": {"geo": {"location": {"lat": 0.0, "lon": 0.0}}},
+    "details": {
+      "operator_id": "...", "registration_id": "...", "self_id_text": "...",
+      "mac_address": "...", "protocol": "...", "rssi": -68,
+      "range_m": 1234.5, "bearing_deg": 215.0, "bearing_cardinal": "SW",
+      "speed_mps": 5.2, "direction_deg": 240.0,
+      "altitude_m_agl": 42.0, "detail": "..."
+    }
+  }
+}
+```
+
+`observer.geo.location` is included when the receiver has a GPS fix; `source.geo.location` is included when the drone is broadcasting a position. Severity follows the ECS convention (lower = more urgent): warnings (`new_drone`, `altitude_max`, `speed_max`) are `40`, informational events (`signal_lost`) are `70`. Friendly-tagged drones do not fire alerts when the operator-side "Alert on Friendly drones" toggle is off, so they do not hit this endpoint either.
+
+Synthetic test alerts emitted by the **Send Test Message** button use `rule.category: "test"`, `event.action: "test"`, `event.severity: 70`, and serial `TEST-0000` so the receiver can recognise and exclude them from operational dashboards.
 
 ---
 

--- a/sparrow-droneid/sparrow_droneid/backend/alert_engine.py
+++ b/sparrow-droneid/sparrow_droneid/backend/alert_engine.py
@@ -116,6 +116,19 @@ class AlertEngine:
         self._slack_webhook_url: str = self._db.get_setting('alert_slack_webhook_url', '') or ''
         self._slack_display_name: str = self._db.get_setting('alert_slack_display_name', 'Sparrow DroneID') or 'Sparrow DroneID'
 
+        # API-based alert delivery: ECS-shaped POST to a generic alert
+        # ingest endpoint. base_url is the full root including any path
+        # prefix (e.g. https://host:port/some/api/root); the notifier
+        # appends /v1/alerts and /v1/alerts/verify.
+        self._api_enabled: bool      = _bool('alert_api_enabled', False)
+        self._api_base_url: str      = self._db.get_setting('alert_api_base_url', '') or ''
+        self._api_domain: str        = self._db.get_setting('alert_api_domain', '') or ''
+        self._api_token: str         = self._db.get_setting('alert_api_token', '') or ''
+        self._api_verify_tls: bool   = _bool('alert_api_verify_tls', True)
+        # operator_name flows into the observer.name field on outbound
+        # alerts; falls back to a generic label if not configured.
+        self._operator_name: str     = self._db.get_setting('operator_name', '') or ''
+
     def reload_config(self) -> None:
         """Re-read alert configuration from the database."""
         self._load_config()
@@ -490,6 +503,9 @@ class AlertEngine:
         if self._slack_enabled and self._slack_webhook_url:
             self._post_slack(alert_dict)
 
+        if self._api_enabled and self._api_base_url and self._api_token:
+            self._post_api(alert_dict)
+
     def _run_script(self, alert_dict: dict) -> None:
         """Invoke the external alert script in a daemon thread.
 
@@ -660,3 +676,316 @@ class AlertEngine:
             return {'success': True, 'message': 'Test message sent'}
         except Exception as e:
             return {'success': False, 'error': str(e)}
+
+    # ------------------------------------------------------------------ #
+    # API-based alert delivery                                            #
+    # ------------------------------------------------------------------ #
+
+    # Suppress the InsecureRequestWarning that urllib3 logs every time a
+    # request is made with verify=False.  Operators who disable TLS
+    # verification have already made that choice in settings; one log
+    # warning per process is enough.  Best-effort.
+    try:
+        import urllib3 as _urllib3
+        _urllib3.disable_warnings(_urllib3.exceptions.InsecureRequestWarning)
+    except Exception:
+        pass
+
+    # Map alert types to ECS severity numerics (lower = more urgent).
+    # Mirrors the convention used by sibling bridges (AIS, ACARS, ADS-B).
+    _API_SEVERITY_MAP = {
+        'new_drone':    40,   # warning — operator should look
+        'altitude_max': 40,
+        'speed_max':    40,
+        'signal_lost':  70,   # info — informational
+    }
+
+    def _build_api_payload(self, alert_dict: dict, is_test: bool = False) -> dict:
+        """Build the ECS-shaped JSON body for one outbound alert.
+
+        Generic payload — no project-specific terms in the wire format.
+        observer / source.geo / rule / event / labels follow ECS conventions
+        so the receiving system can route without app knowledge.
+        """
+        alert_type = alert_dict.get('alert_type', 'unknown')
+        type_labels = {
+            'new_drone':    'New drone detected',
+            'altitude_max': 'Drone altitude violation',
+            'speed_max':    'Drone speed violation',
+            'signal_lost':  'Drone signal lost',
+        }
+        if is_test:
+            rule_name = 'API test message'
+            rule_category = 'test'
+            severity_num = 70
+            action = 'test'
+            message = f'Test message from {self._operator_name or "Sparrow DroneID"}'
+        else:
+            rule_name = type_labels.get(
+                alert_type, alert_type.replace('_', ' ').title())
+            rule_category = 'drone_detection'
+            severity_num = self._API_SEVERITY_MAP.get(alert_type, 70)
+            action = alert_type
+            # Reuse the operator-facing Slack message text body so the
+            # receiving system sees the same human-readable summary.
+            message = self._format_slack_message(alert_dict)
+
+        observer: Dict = {
+            'name': self._operator_name or 'Sparrow DroneID',
+            'type': 'drone-sensor',
+        }
+        if self._gps:
+            rx_lat, rx_lon, _rx_alt = self._gps.get_receiver_position()
+            if rx_lat != 0.0 or rx_lon != 0.0:
+                observer['geo'] = {'location': {
+                    'lat': float(rx_lat), 'lon': float(rx_lon)}}
+
+        body: Dict = {
+            'domain': self._api_domain,
+            'alert': {
+                'message': message,
+                'observer': observer,
+                'rule':  {'name': rule_name, 'category': rule_category},
+                'event': {
+                    'severity': severity_num,
+                    'category': 'network',
+                    'action':   action,
+                },
+                'labels': {
+                    'serial':      alert_dict.get('serial_number', '') or '',
+                    'vendor':      alert_dict.get('vendor', '') or '',
+                    'ua_type':     alert_dict.get('ua_type_name', '') or '',
+                    'alert_type':  alert_type,
+                },
+                'details': {
+                    'operator_id':       alert_dict.get('operator_id', ''),
+                    'registration_id':   alert_dict.get('registration_id', ''),
+                    'self_id_text':      alert_dict.get('self_id_text', ''),
+                    'mac_address':       alert_dict.get('mac_address', ''),
+                    'protocol':          alert_dict.get('protocol', ''),
+                    'rssi':              alert_dict.get('rssi'),
+                    'range_m':           alert_dict.get('range_m'),
+                    'bearing_deg':       alert_dict.get('bearing_deg'),
+                    'bearing_cardinal':  alert_dict.get('bearing_cardinal', ''),
+                    'speed_mps':         alert_dict.get('speed'),
+                    'direction_deg':     alert_dict.get('direction'),
+                    'altitude_m_agl':    alert_dict.get('drone_height_agl'),
+                    'detail':            alert_dict.get('detail', ''),
+                },
+            },
+        }
+
+        # Source geo: drone position when broadcast.  (0, 0) is treated as
+        # absent — the device hasn't transmitted a position yet.
+        drone_lat = alert_dict.get('drone_lat')
+        drone_lon = alert_dict.get('drone_lon')
+        if drone_lat and drone_lon and (drone_lat != 0.0 or drone_lon != 0.0):
+            body['alert']['source'] = {'geo': {'location': {
+                'lat': float(drone_lat), 'lon': float(drone_lon)}}}
+        return body
+
+    def _post_api(self, alert_dict: dict) -> None:
+        """Dispatch an alert to the configured API endpoint in a daemon thread.
+
+        Fire-and-forget — failures are logged but never block detection or
+        the rest of the alert pipeline (script / Slack / DB / on_alert).
+        Retries 503 with exponential backoff; aborts on 4xx without retry.
+        """
+        url = self._api_base_url.rstrip('/') + '/v1/alerts'
+        token = self._api_token
+        domain = self._api_domain
+        verify_tls = self._api_verify_tls
+        payload = self._build_api_payload(alert_dict, is_test=False)
+
+        def _send():
+            headers = {
+                'Authorization': f'Bearer {token}',
+                'Content-Type':  'application/json',
+            }
+            backoff = 1.0
+            for attempt in range(4):  # 1 initial + 3 retries on 503
+                try:
+                    resp = _requests.post(url, json=payload, headers=headers,
+                                          timeout=15, verify=verify_tls)
+                except _requests.RequestException as exc:
+                    log.warning("alert_engine: API POST network error "
+                                "(attempt %d/4): %s", attempt + 1, exc)
+                    if attempt < 3:
+                        time.sleep(backoff)
+                        backoff *= 2
+                    continue
+                if resp.status_code == 201:
+                    return
+                if resp.status_code == 503 and attempt < 3:
+                    log.warning(
+                        "alert_engine: API returned 503 (attempt %d/4) — "
+                        "retrying in %.1fs", attempt + 1, backoff)
+                    time.sleep(backoff)
+                    backoff *= 2
+                    continue
+                if resp.status_code == 200:
+                    # Some endpoints reply 200 with status:dropped when the
+                    # domain is disabled upstream.  Log and stop.
+                    try:
+                        if resp.json().get('status') == 'dropped':
+                            log.warning(
+                                "alert_engine: API reports domain '%s' is "
+                                "disabled — alert dropped upstream", domain)
+                            return
+                    except ValueError:
+                        pass
+                log.error("alert_engine: API POST failed status=%d body=%s",
+                          resp.status_code, resp.text[:200])
+                return
+
+        t = threading.Thread(target=_send, daemon=True, name='alert-api')
+        t.start()
+
+    @staticmethod
+    def _api_verify_request(base_url: str, domain: str, token: str,
+                            verify_tls: bool) -> dict:
+        """Call the verify endpoint. Returns {success, message/error}.
+
+        Pure static helper: receives all credentials so the api-test handler
+        can call it directly without depending on instance state.  Error
+        messages are operator-actionable (auth vs URL vs network).
+        """
+        if not base_url:
+            return {'success': False, 'error': 'API endpoint root is required.'}
+        if not domain:
+            return {'success': False, 'error': 'Domain is required.'}
+        if not token:
+            return {'success': False, 'error': 'Bearer token is required.'}
+        url = base_url.rstrip('/') + '/v1/alerts/verify'
+        headers = {
+            'Authorization': f'Bearer {token}',
+            'Content-Type':  'application/json',
+        }
+        try:
+            resp = _requests.post(url, json={'domain': domain},
+                                  headers=headers, timeout=10,
+                                  verify=verify_tls)
+        except _requests.exceptions.SSLError as exc:
+            return {'success': False,
+                    'error': f'TLS verification failed: {exc}. '
+                             'Disable "Verify TLS" if the endpoint uses a '
+                             'self-signed or private-CA certificate.'}
+        except _requests.exceptions.ConnectionError as exc:
+            return {'success': False,
+                    'error': f'Could not reach the server: {exc}. '
+                             'Check the endpoint root URL and network access.'}
+        except _requests.exceptions.Timeout:
+            return {'success': False,
+                    'error': 'Request timed out after 10s.'}
+        except _requests.RequestException as exc:
+            return {'success': False, 'error': f'Request error: {exc}'}
+
+        if resp.status_code == 200:
+            try:
+                ok = resp.json().get('status') == 'ok'
+            except ValueError:
+                ok = False
+            if ok:
+                return {'success': True,
+                        'message': f"Authentication verified for domain '{domain}'."}
+            return {'success': False,
+                    'error': f'Server returned 200 but unexpected body: '
+                             f'{resp.text[:200]}'}
+        if resp.status_code == 401:
+            return {'success': False,
+                    'error': 'Authentication failed (401) — check the '
+                             'domain and bearer token.'}
+        if resp.status_code == 404:
+            return {'success': False,
+                    'error': 'Endpoint not found (404) — check the API root '
+                             'URL includes any required path prefix.'}
+        if resp.status_code == 503:
+            return {'success': False,
+                    'error': 'Server reported temporary unavailability (503).'}
+        return {'success': False,
+                'error': f'Unexpected response status {resp.status_code}: '
+                         f'{resp.text[:200]}'}
+
+    def test_api_auth(self) -> dict:
+        """Convenience wrapper: verify with the engine's currently-loaded
+        API credentials.  Caller typically just reloads config first via
+        reload_config() so settings just saved are visible."""
+        return self._api_verify_request(
+            self._api_base_url, self._api_domain, self._api_token,
+            self._api_verify_tls)
+
+    def test_api_send(self) -> dict:
+        """Send a synthetic test alert to the configured endpoint.  Returns
+        {success, message/error}.  Uses rule.category='test' and a sentinel
+        serial so the receiver UI can recognise it as a test artifact."""
+        base_url = self._api_base_url
+        domain = self._api_domain
+        token = self._api_token
+        verify_tls = self._api_verify_tls
+        if not base_url:
+            return {'success': False, 'error': 'API endpoint root is required.'}
+        if not domain:
+            return {'success': False, 'error': 'Domain is required.'}
+        if not token:
+            return {'success': False, 'error': 'Bearer token is required.'}
+
+        synthetic = {
+            'alert_type':      'test',
+            'serial_number':   'TEST-0000',
+            'detail':          'Synthetic alert generated by the Sparrow DroneID Send-Test action.',
+            'drone_lat':       0.0,
+            'drone_lon':       0.0,
+            'drone_height_agl': 0,
+            'vendor':          'Sparrow DroneID (test)',
+            'ua_type_name':    'Test',
+        }
+        payload = self._build_api_payload(synthetic, is_test=True)
+        url = base_url.rstrip('/') + '/v1/alerts'
+        headers = {
+            'Authorization': f'Bearer {token}',
+            'Content-Type':  'application/json',
+        }
+        try:
+            resp = _requests.post(url, json=payload, headers=headers,
+                                  timeout=10, verify=verify_tls)
+        except _requests.exceptions.SSLError as exc:
+            return {'success': False,
+                    'error': f'TLS verification failed: {exc}. '
+                             'Disable "Verify TLS" if the endpoint uses a '
+                             'self-signed or private-CA certificate.'}
+        except _requests.exceptions.ConnectionError as exc:
+            return {'success': False,
+                    'error': f'Could not reach the server: {exc}.'}
+        except _requests.exceptions.Timeout:
+            return {'success': False, 'error': 'Request timed out after 10s.'}
+        except _requests.RequestException as exc:
+            return {'success': False, 'error': f'Request error: {exc}'}
+
+        if resp.status_code == 201:
+            try:
+                alert_id = resp.json().get('alert_id', '?')
+            except ValueError:
+                alert_id = '?'
+            return {'success': True,
+                    'message': f'Test alert accepted (alert_id={alert_id}).'}
+        if resp.status_code == 200:
+            try:
+                if resp.json().get('status') == 'dropped':
+                    return {'success': False,
+                            'error': f"Server accepted the request but "
+                                     f"reports domain '{domain}' is disabled "
+                                     f"upstream — alert dropped."}
+            except ValueError:
+                pass
+        if resp.status_code == 401:
+            return {'success': False,
+                    'error': 'Authentication failed (401) — check domain and token.'}
+        if resp.status_code == 400:
+            return {'success': False,
+                    'error': f'Server rejected payload (400): {resp.text[:200]}'}
+        if resp.status_code == 503:
+            return {'success': False,
+                    'error': 'Server reported temporary unavailability (503).'}
+        return {'success': False,
+                'error': f'Unexpected response status {resp.status_code}: '
+                         f'{resp.text[:200]}'}

--- a/sparrow-droneid/sparrow_droneid/backend/api_handler.py
+++ b/sparrow-droneid/sparrow_droneid/backend/api_handler.py
@@ -558,6 +558,7 @@ def _coerce_settings(raw: Dict[str, str]) -> Dict[str, Any]:
         'https_enabled', 'cot_enabled',
         'alert_audio_enabled', 'alert_visual_enabled', 'alert_script_enabled',
         'alert_slack_enabled', 'alert_friendly_enabled',
+        'alert_api_enabled', 'alert_api_verify_tls',
         'tile_cache_enabled',
         'wifi_ssid_enabled',
         'es_enabled', 'es_verify_tls', 'es_dashboards_verify_tls',
@@ -568,6 +569,7 @@ def _coerce_settings(raw: Dict[str, str]) -> Dict[str, Any]:
     # Sensitive fields: show '(set)' if non-empty, '' if empty — never reveal value.
     sensitive_keys = {
         'auth_token',
+        'alert_api_token',
         'es_password', 'es_api_key',
         'es_dashboards_password', 'es_dashboards_api_key',
     }
@@ -1242,6 +1244,117 @@ def api_alerts_slack_test(req: RequestHandler):
     webhook_url = req.json_data.get('webhook_url', '')
     display_name = req.json_data.get('display_name', 'Sparrow DroneID')
     result = AlertEngine.test_slack(webhook_url, display_name)
+    req._send_ok(result)
+
+
+def _resolve_api_test_token(submitted: str) -> str:
+    """Resolve the bearer token from a test-form submission.
+
+    The settings GET endpoint masks the stored token as '(set)'; if that
+    placeholder comes back to us in a test submission it means the user
+    didn't retype the token and wants us to use the stored value.
+    """
+    if submitted and submitted != '(set)':
+        return submitted
+    if _db is None:
+        return ''
+    return _db.get_setting('alert_api_token', '') or ''
+
+
+@router.route('POST', '/api/v1/alerts/api-test', spec={
+    'summary': 'Verify API-based alerting credentials',
+    'tags': ['Alerts'],
+    'requestBody': json_body_inline(
+        {'base_url':   {'type': 'string', 'description': 'Full API endpoint root URL (e.g. http://MY_API_HOST:PORT/API_ROOT)'},
+         'domain':     {'type': 'string', 'description': 'API alert domain'},
+         'token':      {'type': 'string', 'description': 'Bearer token (use "(set)" to test the stored value)'},
+         'verify_tls': {'type': 'boolean', 'description': 'Verify the server\'s TLS certificate'}},
+        required_props=['base_url', 'domain'],
+        description='API alert verification parameters',
+    ),
+    'responses': {
+        '200': response_inline(
+            {'success': {'type': 'boolean'},
+             'message': {'type': 'string'},
+             'error':   {'type': 'string'}},
+            'Verification result',
+        ),
+    },
+})
+def api_alerts_api_test(req: RequestHandler):
+    """Verify the configured API alerting credentials by calling the
+    upstream /v1/alerts/verify endpoint.  Does NOT send any alert."""
+    if req.json_data is None:
+        req._send_error(400, ErrorCode.VALIDATION_ERROR, 'JSON body required')
+        return
+    base_url   = (req.json_data.get('base_url', '') or '').strip()
+    domain     = (req.json_data.get('domain', '') or '').strip()
+    token      = _resolve_api_test_token(req.json_data.get('token', '') or '')
+    verify_tls = bool(req.json_data.get('verify_tls', True))
+    result = AlertEngine._api_verify_request(base_url, domain, token, verify_tls)
+    req._send_ok(result)
+
+
+@router.route('POST', '/api/v1/alerts/api-send-test', spec={
+    'summary': 'Send a synthetic test alert to the configured API endpoint',
+    'tags': ['Alerts'],
+    'requestBody': json_body_inline(
+        {'base_url':   {'type': 'string'},
+         'domain':     {'type': 'string'},
+         'token':      {'type': 'string', 'description': 'Bearer token (use "(set)" to send with the stored value)'},
+         'verify_tls': {'type': 'boolean'}},
+        required_props=['base_url', 'domain'],
+        description='API alert send-test parameters',
+    ),
+    'responses': {
+        '200': response_inline(
+            {'success': {'type': 'boolean'},
+             'message': {'type': 'string'},
+             'error':   {'type': 'string'}},
+            'Send-test result',
+        ),
+    },
+})
+def api_alerts_api_send_test(req: RequestHandler):
+    """Build a synthetic test alert and POST it to the configured endpoint.
+
+    Uses rule.category='test' and a sentinel serial ('TEST-0000') so the
+    receiving system can recognise it as a test artifact and exclude it
+    from operational dashboards.
+    """
+    if req.json_data is None:
+        req._send_error(400, ErrorCode.VALIDATION_ERROR, 'JSON body required')
+        return
+    if _alert_engine is None:
+        req._send_error(503, ErrorCode.SERVICE_UNAVAILABLE,
+                        'Alert engine not available')
+        return
+    # Persist the submitted credentials to a temporary engine state so
+    # _build_api_payload + test_api_send see the form values, not the
+    # last-saved values.  We snapshot/restore around the test so live
+    # config is unaffected.
+    base_url   = (req.json_data.get('base_url', '') or '').strip()
+    domain     = (req.json_data.get('domain', '') or '').strip()
+    token      = _resolve_api_test_token(req.json_data.get('token', '') or '')
+    verify_tls = bool(req.json_data.get('verify_tls', True))
+
+    snapshot = (
+        _alert_engine._api_base_url,
+        _alert_engine._api_domain,
+        _alert_engine._api_token,
+        _alert_engine._api_verify_tls,
+    )
+    try:
+        _alert_engine._api_base_url   = base_url
+        _alert_engine._api_domain     = domain
+        _alert_engine._api_token      = token
+        _alert_engine._api_verify_tls = verify_tls
+        result = _alert_engine.test_api_send()
+    finally:
+        (_alert_engine._api_base_url,
+         _alert_engine._api_domain,
+         _alert_engine._api_token,
+         _alert_engine._api_verify_tls) = snapshot
     req._send_ok(result)
 
 
@@ -2026,6 +2139,8 @@ _SETTINGS_WRITABLE = frozenset({
     'alert_script_enabled', 'alert_script_path',
     'alert_friendly_enabled',
     'alert_slack_enabled', 'alert_slack_webhook_url', 'alert_slack_display_name',
+    'alert_api_enabled', 'alert_api_base_url', 'alert_api_domain',
+    'alert_api_token', 'alert_api_verify_tls',
     'tile_cache_enabled',
     'monitor_interface',
     'operator_name',

--- a/sparrow-droneid/sparrow_droneid/backend/database.py
+++ b/sparrow-droneid/sparrow_droneid/backend/database.py
@@ -191,6 +191,15 @@ class Database:
             'alert_slack_enabled': 'false',
             'alert_slack_webhook_url': '',
             'alert_slack_display_name': 'Sparrow DroneID',
+            # API-based alert delivery (generic ECS-shaped POST to an
+            # external alert ingest API).  Default off; existing installs
+            # inherit these via INSERT OR IGNORE on next startup, leaving
+            # the channel disabled until the operator configures it.
+            'alert_api_enabled': 'false',
+            'alert_api_base_url': '',
+            'alert_api_domain': '',
+            'alert_api_token': '',
+            'alert_api_verify_tls': 'true',
             'tile_cache_enabled': 'true',
             'monitor_interface': '',
             'operator_name': '',

--- a/sparrow-droneid/sparrow_droneid/frontend/js/settings.js
+++ b/sparrow-droneid/sparrow_droneid/frontend/js/settings.js
@@ -407,6 +407,72 @@ const SettingsManager = (() => {
                 </button>
               </div>
 
+              <hr class="my-2">
+
+              <div class="mb-3">
+                <label class="form-label">API-Based Alerting</label>
+                <div class="form-check form-switch">
+                  <input class="form-check-input" type="checkbox" id="s_alert_api" ${_checked(s.alert_api_enabled)}>
+                  <label class="form-check-label" for="s_alert_api">Send drone alerts to an external API</label>
+                </div>
+                <small class="text-muted">
+                  POSTs an ECS-shaped JSON alert to a generic ingest endpoint
+                  with a bearer-token Authorization header. See the README for
+                  the payload schema and endpoint contract.
+                </small>
+              </div>
+
+              <div class="mb-3">
+                <label class="form-label" for="s_api_base_url">API Endpoint Root</label>
+                <input type="text" class="form-control form-control-sm" id="s_api_base_url"
+                  value="${_esc(s.alert_api_base_url || '')}"
+                  placeholder="http://MY_API_HOST:PORT/API_ROOT">
+                <small class="text-muted">
+                  Full root including any path prefix; the bridge appends
+                  <code>/v1/alerts</code> and <code>/v1/alerts/verify</code>.
+                </small>
+              </div>
+
+              <div class="mb-3">
+                <label class="form-label" for="s_api_domain">Domain</label>
+                <input type="text" class="form-control form-control-sm" id="s_api_domain"
+                  value="${_esc(s.alert_api_domain || '')}"
+                  style="max-width:300px;">
+              </div>
+
+              <div class="mb-3">
+                <label class="form-label" for="s_api_token">Bearer Token</label>
+                <div class="input-group input-group-sm" style="max-width:500px;">
+                  <input type="password" class="form-control" id="s_api_token"
+                    value="${_esc(s.alert_api_token || '')}"
+                    placeholder="${s.alert_api_token === '(set)' ? '(set — leave unchanged to keep)' : ''}"
+                    autocomplete="off">
+                  <button class="btn btn-outline-secondary" type="button" id="btn_api_token_show"
+                    title="Show/hide token">
+                    <i class="bi bi-eye"></i>
+                  </button>
+                </div>
+              </div>
+
+              <div class="mb-3">
+                <div class="form-check form-switch">
+                  <input class="form-check-input" type="checkbox" id="s_alert_api_verify_tls" ${_checked(s.alert_api_verify_tls !== false)}>
+                  <label class="form-check-label" for="s_alert_api_verify_tls">Verify TLS certificate</label>
+                </div>
+                <small class="text-muted">
+                  Uncheck for self-signed or private-CA endpoints.
+                </small>
+              </div>
+
+              <div class="mb-0 d-flex gap-2">
+                <button class="btn btn-sm btn-outline-secondary" id="btn_api_test_auth" type="button">
+                  <i class="bi bi-shield-check me-1"></i>Test Auth
+                </button>
+                <button class="btn btn-sm btn-outline-secondary" id="btn_api_send_test" type="button">
+                  <i class="bi bi-send me-1"></i>Send Test Message
+                </button>
+              </div>
+
             </div>
           </div>
 
@@ -1065,6 +1131,77 @@ const SettingsManager = (() => {
       }
       btn.disabled = false;
       btn.innerHTML = '<i class="bi bi-send me-1"></i>Test Slack';
+    });
+
+    // API-based alerting: bearer token show/hide.  We swap input type, not the
+    // value, so the field is always submittable and Save Settings still gates
+    // on the '(set)' placeholder via the _collect token guard.
+    document.getElementById('btn_api_token_show')?.addEventListener('click', () => {
+      const input = document.getElementById('s_api_token');
+      const icon = document.querySelector('#btn_api_token_show i');
+      if (!input) return;
+      if (input.type === 'password') {
+        input.type = 'text';
+        if (icon) { icon.classList.remove('bi-eye'); icon.classList.add('bi-eye-slash'); }
+      } else {
+        input.type = 'password';
+        if (icon) { icon.classList.remove('bi-eye-slash'); icon.classList.add('bi-eye'); }
+      }
+    });
+
+    // Helper: gather the API form values for either test endpoint.
+    // Token retains the '(set)' placeholder when the user didn't retype —
+    // the backend resolves it to the stored value.
+    const _collectApiTestBody = () => {
+      const baseUrl = document.getElementById('s_api_base_url')?.value?.trim() || '';
+      const domain  = document.getElementById('s_api_domain')?.value?.trim() || '';
+      const token   = document.getElementById('s_api_token')?.value || '';
+      const verifyTls = !!(document.getElementById('s_alert_api_verify_tls')?.checked);
+      return { base_url: baseUrl, domain, token, verify_tls: verifyTls };
+    };
+
+    // API-based alerting: Test Auth — calls /alerts/api-test (verify endpoint).
+    document.getElementById('btn_api_test_auth')?.addEventListener('click', async () => {
+      const body = _collectApiTestBody();
+      if (!body.base_url) { Utils.toast('Enter the API endpoint root first', 'warning'); return; }
+      if (!body.domain)   { Utils.toast('Enter the API domain first',         'warning'); return; }
+      const btn = document.getElementById('btn_api_test_auth');
+      btn.disabled = true;
+      btn.innerHTML = '<i class="bi bi-hourglass-split me-1"></i>Testing…';
+      try {
+        const resp = await Api.post('/alerts/api-test', body);
+        if (resp.success) {
+          Utils.toast(resp.message || 'Authentication verified', 'success');
+        } else {
+          Utils.toast('Auth test failed: ' + (resp.error || 'Unknown error'), 'danger');
+        }
+      } catch (e) {
+        Utils.toast('Auth test error: ' + e.message, 'danger');
+      }
+      btn.disabled = false;
+      btn.innerHTML = '<i class="bi bi-shield-check me-1"></i>Test Auth';
+    });
+
+    // API-based alerting: Send Test Message — POSTs a synthetic alert.
+    document.getElementById('btn_api_send_test')?.addEventListener('click', async () => {
+      const body = _collectApiTestBody();
+      if (!body.base_url) { Utils.toast('Enter the API endpoint root first', 'warning'); return; }
+      if (!body.domain)   { Utils.toast('Enter the API domain first',         'warning'); return; }
+      const btn = document.getElementById('btn_api_send_test');
+      btn.disabled = true;
+      btn.innerHTML = '<i class="bi bi-hourglass-split me-1"></i>Sending…';
+      try {
+        const resp = await Api.post('/alerts/api-send-test', body);
+        if (resp.success) {
+          Utils.toast(resp.message || 'Test alert sent', 'success');
+        } else {
+          Utils.toast('Send test failed: ' + (resp.error || 'Unknown error'), 'danger');
+        }
+      } catch (e) {
+        Utils.toast('Send test error: ' + e.message, 'danger');
+      }
+      btn.disabled = false;
+      btn.innerHTML = '<i class="bi bi-send me-1"></i>Send Test Message';
     });
 
     // Purge data
@@ -1753,6 +1890,25 @@ const SettingsManager = (() => {
     boolField ('s_alert_slack',      'alert_slack_enabled');
     strField  ('s_slack_webhook',    'alert_slack_webhook_url');
     strField  ('s_slack_name',       'alert_slack_display_name');
+
+    // API-based alerting — bearer token uses the '(set)' sensitive-field
+    // pattern: only send the token to the backend when the user actually
+    // typed a new value, otherwise the stored one is preserved.
+    boolField ('s_alert_api',           'alert_api_enabled');
+    strField  ('s_api_base_url',        'alert_api_base_url');
+    strField  ('s_api_domain',          'alert_api_domain');
+    boolField ('s_alert_api_verify_tls','alert_api_verify_tls');
+    const apiTok = document.getElementById('s_api_token')?.value || '';
+    if (apiTok && apiTok !== '(set)') changes.alert_api_token = apiTok;
+
+    // Enable-without-creds guard, matching the Slack pattern.
+    if (changes.alert_api_enabled &&
+        (!changes.alert_api_base_url || !changes.alert_api_domain)) {
+      changes.alert_api_enabled = false;
+      const apiToggle = document.getElementById('s_alert_api');
+      if (apiToggle) apiToggle.checked = false;
+      Utils.toast('API-based alerting requires endpoint root and domain — disabled.', 'warning');
+    }
     boolField ('s_wifi_ssid_enabled',       'wifi_ssid_enabled');
     strField  ('s_wifi_ssid_agent_url',     'wifi_ssid_agent_url');
     strField  ('s_wifi_ssid_agent_iface',   'wifi_ssid_agent_interface');


### PR DESCRIPTION
New optional notifier that POSTs each fired alert to a generic external alert-ingest endpoint with bearer-token auth. Sits next to the existing Slack delivery in the same alert pipeline; default off; existing installs inherit the new settings keys via the existing INSERT OR IGNORE flow at DB init time, so no schema migration is needed.

Settings (under Alerts in the UI):
  * Enable toggle
  * API Endpoint Root (full root incl. any path prefix)
  * Domain
  * Bearer Token (masked, show/hide eye icon, '(set)' placeholder so the stored value is preserved when the field is left untouched)
  * Verify TLS (uncheck for self-signed / private-CA endpoints)
  * Test Auth button — calls {root}/v1/alerts/verify with actionable feedback (401 vs 503 vs TLS vs network all distinct)
  * Send Test Message button — POSTs a synthetic alert with rule.category='test' and serial 'TEST-0000' so the receiver can be exercised end-to-end

Outbound payload is ECS-shaped (observer / rule / event / labels / source.geo / details). Severity follows an ECS numeric scale: new_drone/altitude_max/speed_max=40, signal_lost=70. Friendly-tagged drones continue to be suppressed (gate lives upstream of _fire_alert; both Slack and the new API inherit identically).

Dispatch is fire-and-forget on a daemon thread (matches the Slack pattern); never blocks detection. 503 responses retry with exponential backoff up to 15s total; 4xx aborts without retry.

Files touched (all additive):
  * database.py — 5 new keys w/ safe defaults
  * alert_engine.py — _post_api, _build_api_payload, _api_verify_request, test_api_send, severity map
  * api_handler.py — /alerts/api-test, /alerts/api-send-test endpoints, _SETTINGS_WRITABLE / sensitive_keys / bool_keys updated, snapshot/restore around send-test so test-with-form-values can't leak into live engine state
  * frontend/js/settings.js — new card under Slack, two test buttons, show/hide token, _collect block with enable-without-creds guard
  * README.md — capabilities bullet + new section w/ generic example placeholders, endpoint contract, payload schema